### PR TITLE
Add trigger_action which mask/unmask cam control

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ If you don't need the demo just ignore the demo folder and connect your camera w
 - Vector3 max_speed - Set maximum movement speed for each axes separately. Default value is (1.0, 1.0, 1.0).
 
 #### Input Actions / Controls
+
+- String trigger_action: Action name to enable freelook and/or movement. If this action is specified, freelook and movement flag is masked with the action state. Default action is "camera_control".
+
 ##### Freelook
 - String rotate_left_action - Input Action for Left rotation. Default action is "".
 - String rotate_right_action: Input Action for Right rotation. Default action is "".

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you don't need the demo just ignore the demo folder and connect your camera w
 
 #### Input Actions / Controls
 
-- String trigger_action: Action name to enable freelook and/or movement. If this action is specified, freelook and movement flag is masked with the action state. Default action is "camera_control".
+- String trigger_action: Action name to enable freelook and/or movement. If this action is specified, freelook and movement flag is masked with the action state. Default action is "".
 
 ##### Freelook
 - String rotate_left_action - Input Action for Left rotation. Default action is "".

--- a/assets/maujoe.camera_control/demo/demo.tscn
+++ b/assets/maujoe.camera_control/demo/demo.tscn
@@ -32,6 +32,7 @@ rotate_left_action = "ui_rotate_left"
 rotate_right_action = "ui_rotate_right"
 rotate_up_action = "ui_rotate_up"
 rotate_down_action = "ui-rotate_down"
+trigger_action = ""
 
 [node name="DirectionalLight" type="DirectionalLight" parent="."]
 transform = Transform( 1, 0, 0, 0, 0.866025, 0.5, 0, -0.5, 0.866025, 0, 8, 0 )

--- a/assets/maujoe.camera_control/scripts/camera_control.gd
+++ b/assets/maujoe.camera_control/scripts/camera_control.gd
@@ -42,6 +42,7 @@ export var left_action = "ui_left"
 export var right_action = "ui_right"
 export var up_action = "ui_page_up"
 export var down_action = "ui_page_down"
+export var trigger_action = "camera_control"
 
 # Gui settings
 export var use_gui = true
@@ -58,6 +59,8 @@ var _total_pitch = 0.0
 var _direction = Vector3(0.0, 0.0, 0.0)
 var _speed = Vector3(0.0, 0.0, 0.0)
 var _gui
+
+var _triggered=false
 
 const ROTATION_MULTIPLIER = 500
 
@@ -89,14 +92,21 @@ func _ready():
 		add_child(_gui)
 
 func _input(event):
-		if freelook:
+		if len(trigger_action)!=0:
+			if event.is_action_pressed(trigger_action):
+				_triggered=true
+			elif event.is_action_released(trigger_action):
+				_triggered=false
+		else:
+			_triggered=true
+		if freelook and _triggered:
 			if event is InputEventMouseMotion:
 				_mouse_offset = event.relative
 				
 			_rotation_offset.x = Input.get_action_strength(rotate_right_action) - Input.get_action_strength(rotate_left_action)
 			_rotation_offset.y = Input.get_action_strength(rotate_down_action) - Input.get_action_strength(rotate_up_action)
 	
-		if movement:
+		if movement and _triggered:
 			_direction.x = Input.get_action_strength(right_action) - Input.get_action_strength(left_action)
 			_direction.y = Input.get_action_strength(up_action) - Input.get_action_strength(down_action)
 			_direction.z = Input.get_action_strength(backward_action) - Input.get_action_strength(forward_action)
@@ -104,15 +114,15 @@ func _input(event):
 func _process(delta):
 	if privot:
 		_update_distance()
-	if freelook:
+	if freelook and _triggered:
 		_update_rotation(delta)
-	if movement:
+	if movement and _triggered:
 		_update_movement(delta)
 
 func _physics_process(delta):
 	# Called when collision are enabled
 	_update_distance()
-	if freelook:
+	if freelook and _triggered:
 		_update_rotation(delta)
 
 	var space_state = get_world().get_direct_space_state()

--- a/assets/maujoe.camera_control/scripts/camera_control.gd
+++ b/assets/maujoe.camera_control/scripts/camera_control.gd
@@ -112,17 +112,25 @@ func _input(event):
 			_direction.z = Input.get_action_strength(backward_action) - Input.get_action_strength(forward_action)
 
 func _process(delta):
+	if _triggered:
+		_update_views(delta)
+
+func _update_views(delta):
 	if privot:
 		_update_distance()
-	if freelook and _triggered:
+	if freelook:
 		_update_rotation(delta)
-	if movement and _triggered:
+	if movement:
 		_update_movement(delta)
 
 func _physics_process(delta):
+	if _triggered:
+		_update_views_physics(delta)
+
+func _update_views_physics(delta):
 	# Called when collision are enabled
 	_update_distance()
-	if freelook and _triggered:
+	if freelook:
 		_update_rotation(delta)
 
 	var space_state = get_world().get_direct_space_state()
@@ -209,6 +217,8 @@ func _check_actions(actions=[]):
 func set_privot(value):
 	privot = value
 	_update_process_func()
+	if len(trigger_action)!=0:
+		_update_views(0)
 
 func set_collisions(value):
 	collisions = value

--- a/assets/maujoe.camera_control/scripts/camera_control.gd
+++ b/assets/maujoe.camera_control/scripts/camera_control.gd
@@ -42,7 +42,7 @@ export var left_action = "ui_left"
 export var right_action = "ui_right"
 export var up_action = "ui_page_up"
 export var down_action = "ui_page_down"
-export var trigger_action = "camera_control"
+export var trigger_action = ""
 
 # Gui settings
 export var use_gui = true

--- a/project.godot
+++ b/project.godot
@@ -80,6 +80,11 @@ ui_rotate_down={
 "events": [ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":1.0,"script":null)
  ]
 }
+camera_control={
+"deadzone": 0.5,
+"events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":2,"pressed":false,"doubleclick":false,"script":null)
+ ]
+}
 
 [rendering]
 


### PR DESCRIPTION
This PR adds trigger_action variable to specify a action to mask/unmask freelook and/or movement. With this action specified, the godot editor like experience can be achieved (RMB to look around).
If trigger_action variable is empty string, the behaviour of the script is unchanged as before.