### PR TITLE
Added zooming and offset to collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ func set_action(action: String, config_key: String):
 
 This logic can be used to load key bindings from a configuration file.
 
-## Docummentation:
+## Documentation:
 
 ### Settings available via Editor/GDscript:
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This logic can be used to load key bindings from a configuration file.
 - float `distance` - The distance between the camera and the privot object. Minimum value is 0. Default value is 5.0
 - bool `rotate_privot` - Rotate privot object with the mouselook. Default is false.
 - bool `collision` - The camera avoid it to go through/behind objects. Default is true.
+- float 'collision_buffer' - When colliding with objects offsets camera towards privot to prevent visual clipping.
 
 #### Movement
 - bool `movement` - Enable/disable camera movement (flying). Default is true.
@@ -93,6 +94,13 @@ This logic can be used to load key bindings from a configuration file.
 - String `right_action` - Input Action for Right movement. Default action is "ui_right".
 - String `up_action` - Input Action for upward movement. Default action is "ui_page_up".
 - String `down_action` - Input Action for downward movement. Default action is "ui_page_down".
+- String 'zoom_in_action' - Input Action for the zoom in movement. Default action is "".
+- String 'zoom_out_action' - Input Action for the zoom out movement. Default action is "".
+
+##### Zoom
+- float 'zoom_min' - Minimum percentage of 'distance' to keep the camera away from the privot. Default is 25%
+- float 'zoom_percent' - Percentage of current camera zoom between 'zoom_min' and 'distance'. Default is 0%
+- float 'zoom_step' - Percentage to increase or decrease zoom levels on an input event. Default is 1%
 
 #### Ingame Gui
 - String `gui_action` - Input Action to show/hide the ingame control gui. Default action is "ui_cancel".

--- a/assets/maujoe.camera_control/README.md
+++ b/assets/maujoe.camera_control/README.md
@@ -46,7 +46,7 @@ func set_action(action: String, config_key: String):
 
 This logic can be used to load key bindings from a configuration file.
 
-## Docummentation:
+## Documentation:
 
 ### Settings available via Editor/GDscript:
 

--- a/assets/maujoe.camera_control/demo/demo.tscn
+++ b/assets/maujoe.camera_control/demo/demo.tscn
@@ -32,7 +32,8 @@ rotate_left_action = "ui_rotate_left"
 rotate_right_action = "ui_rotate_right"
 rotate_up_action = "ui_rotate_up"
 rotate_down_action = "ui-rotate_down"
-trigger_action = ""
+zoom_in_action = "ui_zoom_in"
+zoom_out_action = "ui_zoom_out"
 
 [node name="DirectionalLight" type="DirectionalLight" parent="."]
 transform = Transform( 1, 0, 0, 0, 0.866025, 0.5, 0, -0.5, 0.866025, 0, 8, 0 )

--- a/assets/maujoe.camera_control/scripts/camera_control.gd
+++ b/assets/maujoe.camera_control/scripts/camera_control.gd
@@ -148,6 +148,20 @@ func _physics_process(delta):
 	if _triggered:
 		_update_views_physics(delta)
 
+func _force_update( delta ) -> void:
+	#Set Trigger as modes require this boolean as true to run. and we want them to run regardless of trigger when forced.
+	#We backup the current value of the boolean.
+	var tmp = _triggered
+	_triggered = true
+	#Depending on mode of operation call respective function
+	if collisions and privot:
+		_physics_process( delta )
+	else:
+		_process( delta )
+	#Restore the previous value of _triggered
+	#This should be safe as the called functions don't modify the triggered boolean value.
+	_triggered = tmp
+
 func _update_views_physics(delta):
 	# Called when collision are enabled
 	_update_distance()
@@ -258,6 +272,10 @@ func set_enabled(value):
 		Input.set_mouse_mode(mouse_mode)
 		set_process_input(true)
 		_update_process_func()
+		#When scene starts with the camera not initially in the correct position and awaiting input with a privot defined,
+		#Until that first input event is reveived, camera would remain in the wrong initial location
+		#unless we force an initial update here. So we don't have to wait for the first input event(s) to define the _triggered bool.
+		_force_update( 0 )
 	else:
 		set_process(false)
 		set_process_input(false)

--- a/assets/maujoe.camera_control/scripts/camera_control.gd
+++ b/assets/maujoe.camera_control/scripts/camera_control.gd
@@ -122,13 +122,14 @@ func _input(event):
 			_direction.x = Input.get_action_strength(right_action) - Input.get_action_strength(left_action)
 			_direction.y = Input.get_action_strength(up_action) - Input.get_action_strength(down_action)
 			_direction.z = Input.get_action_strength(backward_action) - Input.get_action_strength(forward_action)
-		if zoom_step > 0.0:
-			if event.is_action_pressed(zoom_in_action):
-				#_zoomDir = 1#TODO allow for zoom smoothing over time(?)
-				zoom_percent += zoom_step
-			elif event.is_action_pressed(zoom_out_action):
-				#_zoomDir = -1#TODO allow for zoom smoothing over time(?)
-				zoom_percent -= zoom_step
+		if zoom_step > 0.0 and _triggered:
+			if len(zoom_in_action)!=0 and len(zoom_out_action)!=0:
+				if event.is_action_pressed(zoom_in_action):
+					#_zoomDir = 1#TODO allow for zoom smoothing over time(?)
+					zoom_percent += zoom_step
+				elif event.is_action_pressed(zoom_out_action):
+					#_zoomDir = -1#TODO allow for zoom smoothing over time(?)
+					zoom_percent -= zoom_step
 			set_zoom(zoom_percent)#Apply/update zoom limit
 
 func _process(delta):

--- a/assets/maujoe.camera_control/scripts/camera_control_gui.gd
+++ b/assets/maujoe.camera_control/scripts/camera_control_gui.gd
@@ -24,6 +24,8 @@ var panel
 var mouse_over = false
 var mouse_pressed = false
 
+#warning-ignore:SHADOWED_VARIABLE
+#warning-ignore:SHADOWED_VARIABLE
 func _init(camera, shortcut):
 	self.camera = camera
 	self.shortcut = shortcut
@@ -124,6 +126,14 @@ func _ready():
 		collisions.set_pressed(camera.collisions)
 		collisions.connect("toggled",self,"_on_btn_collisions_toggled")
 
+		var lbl_collision_buffer = Label.new()
+		lbl_collision_buffer.set_text("Collision Buffer")
+
+		var collision_buffer = HScrollBar.new()
+		collision_buffer.set_max(max(camera.distance - camera.zoom_min, 0.0))
+		collision_buffer.set_value(camera.collision_buffer)
+		collision_buffer.connect("value_changed", self, "_in_hsb_collision_buffer_value_changed")
+
 		# Movement
 		var lbl_movement = Label.new()
 		lbl_movement.set_text("Movement")
@@ -156,6 +166,25 @@ func _ready():
 		deceleration.set_value(camera.deceleration)
 		deceleration.connect("value_changed", self, "_in_hsb_deceleration_value_changed")
 
+		var lbl_zoom_min = Label.new()
+		var lbl_zoom_percent = Label.new()
+		var lbl_zoom_step = Label.new()
+		lbl_zoom_min.set_text("Minimum Zoom %")
+		lbl_zoom_percent.set_text("Current Zoom %")
+		lbl_zoom_step.set_text("Zoom Step Amount")
+
+		var zoom_min = HScrollBar.new()
+		zoom_min.set_max(1.0)
+		zoom_min.set_value(camera.zoom_min)
+		zoom_min.connect("value_changed", self, "_in_hsb_zoom_min_value_changed")
+		var zoom_percent = HScrollBar.new()
+		zoom_percent.set_max(1.0)
+		zoom_percent.set_value(camera.zoom_percent)
+		zoom_percent.connect("value_changed", self, "_in_hsb_zoom_percent_value_changed")
+		var zoom_step = SpinBox.new()
+		zoom_step.set_value(camera.zoom_step)
+		zoom_step.connect("value_changed",self,"_on_box_zoom_step_value_changed")
+
 		add_child(panel)
 		panel.add_child(container)
 		container.add_child(lbl_mouse)
@@ -175,6 +204,8 @@ func _ready():
 		container.add_child(lbl_pitch)
 		container.add_child(pitch)
 		container.add_child(collisions)
+		container.add_child(lbl_collision_buffer)
+		container.add_child(collision_buffer)
 		container.add_child(lbl_movement)
 		container.add_child(movement)
 		container.add_child(lbl_speed)
@@ -183,6 +214,12 @@ func _ready():
 		container.add_child(acceleration)
 		container.add_child(lbl_deceleration)
 		container.add_child(deceleration)
+		container.add_child(lbl_zoom_min)
+		container.add_child(zoom_min)
+		container.add_child(lbl_zoom_percent)
+		container.add_child(zoom_percent)
+		container.add_child(lbl_zoom_step)
+		container.add_child(zoom_step)
 		
 		if DRAGGABLE:
 			panel.connect("mouse_entered", self, "_panel_entered")
@@ -211,6 +248,7 @@ func _input(event):
 		elif event is InputEventMouseMotion and mouse_over and mouse_pressed:
 			panel.set_begin(panel.get_begin() + event.relative)
 
+#warning-ignore:SHADOWED_VARIABLE
 func _update_privots(privot):
 	privot.clear()
 	privot.add_item("None")
@@ -281,6 +319,9 @@ func _on_box_pitch_value_changed(value):
 func _on_btn_collisions_toggled(pressed):
 	camera.collisions = pressed
 
+func _in_hsb_collision_buffer_value_changed(value):
+	camera.collision_buffer = value
+
 func _on_btn_movement_toggled(pressed):
 	camera.movement = pressed
 
@@ -294,3 +335,10 @@ func _in_hsb_acceleration_value_changed(value):
 	
 func _in_hsb_deceleration_value_changed(value):
 	camera.deceleration = value
+
+func _in_hsb_zoom_min_value_changed(value):
+	camera.zoom_min = value
+func _in_hsb_zoom_percent_value_changed(value):
+	camera.zoom_percent = value
+func _on_box_zoom_step_value_changed(value):
+	camera.zoom_step = value

--- a/project.godot
+++ b/project.godot
@@ -21,8 +21,9 @@ config/icon="res://assets/maujoe.camera_control/icon.png"
 
 [display]
 
+window/size/height=740
 window/size/test_width=1024
-window/size/test_height=600
+window/size/test_height=740
 
 [input]
 
@@ -83,6 +84,18 @@ ui_rotate_down={
 camera_control={
 "deadzone": 0.5,
 "events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":2,"pressed":false,"doubleclick":false,"script":null)
+ ]
+}
+ui_zoom_in={
+"deadzone": 0.5,
+"events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":4,"pressed":false,"doubleclick":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":true,"control":false,"meta":false,"command":false,"pressed":false,"scancode":61,"unicode":0,"echo":false,"script":null)
+ ]
+}
+ui_zoom_out={
+"deadzone": 0.5,
+"events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":5,"pressed":false,"doubleclick":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":45,"unicode":0,"echo":false,"script":null)
  ]
 }
 


### PR DESCRIPTION
   Thanks for the script! I first used it back in 2018 and wanted to add some of the little things I did to it. If these changes are not wanted or are not implemented as well as could be I appologize for using your time.

   I added the ability to use actions to change the distance by a percentage of the 'distance' variable value so you can scroll your mousewheel to zoom in and out of whatever your looking at.

   Also added an easy to access offset to the ray trace collision position towards the privot to prevent visual clipping. That is to say when you collide with the box to help prevent seeing through the box when at an angle. I realize an offset to the position is probably not the best solution to the clipping but it worked well for most of my use cases, it was simple to implement, and not alot of overhead. The better solution might be to use additional rays to determine if you'd be clipping the object if the camera is at the position but I'm to tired to mess with rays.

   Regardless of wether this ends up being useful or not hope you have a good one.
Edit: Readabilty hopefully.